### PR TITLE
Add default catalog::columns constructor

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -4359,6 +4359,10 @@ string catalog::primary_keys::primary_key_name() const
     return result_.get<string>(5);
 }
 
+catalog::columns::columns()
+{
+}
+
 catalog::columns::columns(result& find_result)
     : result_(find_result)
 {

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1639,6 +1639,7 @@ public:
     class columns
     {
     public:
+        columns();
         bool next();                           ///< Move to the next result in the result set.
         string table_catalog() const;          ///< Fetch table catalog.
         string table_schema() const;           ///< Fetch table schema.


### PR DESCRIPTION
Columns default constructor needed due to cython c++ transcription.